### PR TITLE
streamlining

### DIFF
--- a/src/generate_dataset/make_enhanced_data.py
+++ b/src/generate_dataset/make_enhanced_data.py
@@ -781,7 +781,6 @@ def return_dim_id(path, filename):
 
 
 if __name__ == "__main__":
-    print(sys.argv)
     project_path = Path(os.path.abspath(''))
     data_path = project_path / '..' / '..' /'data'
 
@@ -841,12 +840,13 @@ if __name__ == "__main__":
     df = load_topic_data(df, manual_path, topic_path)
     df = make_and_load_tags(df, raw_path, edit_path)
     
-    if (sys.argv[1] and not sys.argv[1].startswith("-")):
-        ## Path provided
-        if ('.csv' not in sys.argv[1]):
-            print("Provide valid .csv path to write final file to")
-        else:
-            df.to_csv(sys.argv[1], index=False)
+    if (len(sys.argv) > 1):
+        if not sys.argv[1].startswith("-"):
+            ## Path provided
+            if ('.csv' not in sys.argv[1]):
+                print("Provide valid .csv path to write final file to")
+            else:
+                df.to_csv(sys.argv[1], index=False)
     elif ('-f' in sys.argv):
         ## Path not provided but output file already exists
         print("Force overwriting final output file")


### PR DESCRIPTION
Streamlined data pre-processing script.

Main features:
- Moved to pathlib approach for file paths
- Added decorators to all data wrangling functions to monitor number of rows post function
- Added `clean_dep_level` function as this was missing in current milestone and required to make `cleaN_ref_dep_data.xlsx` which is used in `load_dept_vars`
- Fixed incorrect merging in `load_dept_vars` which was merging on `Unit of assessment number` and `inst_id` rather than `uoa_id` and `inst_id` (and commented out code on lines 568:571 that made `uoa_id` identical to `Unit of assessment number`. @crahal double check whether the incorrect merge was used in previous iterations, leading to some duplicate rows (correct number of rows is 6371)
- took `section_columns` argument used in the text-mining functions out of each individual function and as a parameter
- included `sys.argv` approach such that different datasets can be generated (`-bq` collects dimensions data and makes the data paper level, `-top` estimates the topic model (to be finished yet in current script), `-tm` adds text-mining data to the dataset.
- Added `sys.argv` approach to output path of the final file. If none is provided, file simply outputs at the original location `final_path / 'enhanced_ref_data.csv'` unless the file is already there, in which case it only overwrites if `-f` is provided to the call. If a path is provided, the output file is written there.

Proposed approach:
`python3 make_enhanced_data.py [path] [-bq] [-tm] [-top] [-f]`